### PR TITLE
Allow to override all arguments with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 `cheek` aims to be a KISS approach to job scheduling. Focus is on the KISS approach not to necessarily do this in the most robust way possible.
 
+## TOC
+
+- [Getting started](#getting-started)
+- [Scheduler](#scheduler)
+- [UI](#ui)
+- [Configuration](#configuration)
+- [Docker](#docker)
+- [Acknowledgements](#acknowledgements)
+
 
 ## Getting started
 
@@ -56,7 +65,7 @@ If your `command` requires arguments, please make sure to pass them as an array 
 
 The core of `cheek` consists of a scheduler that uses a schedule specified in a `yaml` file to triggers jobs when they are due.
 
-You can launch the scheduler via: 
+You can launch the scheduler via:
 
 ```sh
 cheek run ./path/to/my-schedule.yaml
@@ -78,6 +87,11 @@ The UI requires the scheduler to be up and running.
 
 ![](https://storage.googleapis.com/better-unified/ui-screenshot2.png)
 
+## Configuration
+
+All configuration options are available by checking out `cheek --help` or the help of its subcommands (e.g. `cheek run --help`).
+
+Configuration can be passed as flags to the `cheek` CLI directly. All configuration flags are also possible to set via environment variables. The following environment variables are available, they will override the default and/or set value of their similarly named CLI flags (without the prefix): `CHEEK_PORT`, `CHEEK_SUPPRESSLOGS`, `CHEEK_LOGLEVEL`, `CHEEK_PRETTY`, `CHEEK_HOMEDIR`.
 
 ## Docker
 
@@ -86,6 +100,7 @@ Check out the `Dockerfile` for an example on how to set up `cheek` within the co
 ## Acknowledgements
 
 Thanks goes to:
+
 - [gronx](https://github.com/adhocore/gronx): for allowing me not to worry about CRON strings.
 - [Charm](https://www.charm.sh/): for their bubble-icious TUI libraries.
 - [Sam](https://github.com/sdebruyn) & [Frederik](https://github.com/frederikdesmedt): for valuable code reviews / feedback.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,17 +44,24 @@ func initConfig() {
 	// because tests will often be called without flags
 	// being set
 	viper.SetDefault("port", "8081")
-	viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
+	if err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")); err != nil {
+		fmt.Printf("error binding pflag")
+	}
 
 	viper.SetDefault("suppressLogs", false)
-	viper.BindPFlag("suppressLogs", runCmd.PersistentFlags().Lookup("port"))
-
+	if err := viper.BindPFlag("suppressLogs", runCmd.PersistentFlags().Lookup("port")); err != nil {
+		fmt.Printf("error binding pflag")
+	}
 	viper.SetDefault("logLevel", "info")
-	viper.BindPFlag("logLevel", runCmd.PersistentFlags().Lookup("logLevel"))
-
+	if err := viper.BindPFlag("logLevel", runCmd.PersistentFlags().Lookup("logLevel")); err != nil {
+		fmt.Printf("error binding pflag")
+	}
 	viper.SetDefault("pretty", true)
-	// viper.BindPFlag("pretty", runCmd.PersistentFlags().Lookup("pretty"))
-
+	if err := viper.BindPFlag("pretty", runCmd.PersistentFlags().Lookup("pretty")); err != nil {
+		fmt.Printf("error binding pflag")
+	}
 	viper.SetDefault("homedir", cheek.CheekPath())
-	viper.BindPFlag("homedir", rootCmd.PersistentFlags().Lookup("homedir"))
+	if err := viper.BindPFlag("homedir", rootCmd.PersistentFlags().Lookup("homedir")); err != nil {
+		fmt.Printf("error binding pflag")
+	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestConfig(t *testing.T) {
+	initConfig()
+
+	vs := []bool{
+		viper.IsSet("port"), viper.IsSet("suppressLogs"), viper.IsSet("logLevel"), viper.IsSet("pretty"), viper.IsSet("homedir"),
+	}
+
+	for i, v := range vs {
+		if !v {
+			t.Fatalf("a default viper value has not been set for var with index %v", i)
+		}
+	}
+
+}
+
+func TestEnvVar(t *testing.T) {
+	// check if this works how I assume it works
+	initConfig()
+
+	if !viper.GetBool("pretty") {
+		t.Fatalf("default value not correct")
+	}
+
+	os.Setenv("CHEEK_PRETTY", "false")
+	viper.Reset()
+	initConfig()
+	if viper.GetBool("pretty") {
+		t.Fatalf("env var not picked up")
+	}
+
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,7 +19,6 @@ func TestConfig(t *testing.T) {
 			t.Fatalf("a default viper value has not been set for var with index %v", i)
 		}
 	}
-
 }
 
 func TestEnvVar(t *testing.T) {
@@ -36,5 +35,4 @@ func TestEnvVar(t *testing.T) {
 	if viper.GetBool("pretty") {
 		t.Fatalf("env var not picked up")
 	}
-
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,13 +22,13 @@ var runCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		cheek.ConfigLogger(pretty, logLevel)
-		cheek.RunSchedule(args[0], httpPort, surpressLogs)
+		cheek.RunSchedule(args[0], surpressLogs)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-	runCmd.Flags().BoolVarP(&pretty, "pretty", "p", false, "Output pretty formatted logs to console.")
+	runCmd.Flags().BoolVarP(&pretty, "pretty", "p", true, "Output pretty formatted logs to console.")
 	runCmd.Flags().BoolVarP(&surpressLogs, "surpress-logs", "s", false, "Do not output logs to stdout, only to file.")
-	runCmd.Flags().StringVarP(&logLevel, "log-level", "l", "debug", fmt.Sprintf("Set log level, can be one of %v|%v|%v|%v|%v|%v|%v (only applies to cheek specific logging)", zl.LevelTraceValue, zl.LevelDebugValue, zl.LevelInfoValue, zl.LevelWarnValue, zl.LevelErrorValue, zl.LevelFatalValue, zl.LevelPanicValue))
+	runCmd.Flags().StringVarP(&logLevel, "log-level", "l", "info", fmt.Sprintf("Set log level, can be one of %v|%v|%v|%v|%v|%v|%v (only applies to cheek specific logging)", zl.LevelTraceValue, zl.LevelDebugValue, zl.LevelInfoValue, zl.LevelWarnValue, zl.LevelErrorValue, zl.LevelFatalValue, zl.LevelPanicValue))
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -18,7 +18,7 @@ By default the UI will communicate with the scheduler to receive the latest stat
 Alternatively, the '-schedule' flag allows you to provide a path to the specs YAML. These will be used as backup if the scheduler is not reachable.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		cheek.TUI(httpPort, yamlFile)
+		cheek.TUI(yamlFile)
 	},
 }
 

--- a/pkg/job.go
+++ b/pkg/job.go
@@ -37,7 +37,7 @@ type JobRun struct {
 
 func (j *JobSpec) loadRuns() {
 	const nRuns int = 30
-	logFn := path.Join(cheekPath(), fmt.Sprintf("%s.job.jsonl", j.Name))
+	logFn := path.Join(CheekPath(), fmt.Sprintf("%s.job.jsonl", j.Name))
 	jrs, err := readLastJobRuns(logFn, nRuns)
 	if err != nil {
 		log.Warn().Str("job", j.Name).Err(err).Msgf("could not load job logs from '%s'", logFn)
@@ -46,7 +46,7 @@ func (j *JobSpec) loadRuns() {
 }
 
 func (j *JobRun) logToDisk() {
-	logFn := path.Join(cheekPath(), fmt.Sprintf("%s.job.jsonl", j.Name))
+	logFn := path.Join(CheekPath(), fmt.Sprintf("%s.job.jsonl", j.Name))
 	f, err := os.OpenFile(logFn,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
@@ -60,7 +60,7 @@ func (j *JobRun) logToDisk() {
 	}
 }
 
-func (j *JobSpec) execCommandWithRetry(trigger string, supressLogs bool) {
+func (j *JobSpec) execCommandWithRetry(trigger string, suppressLogs bool) {
 	tries := 0
 	var jr JobRun
 	const timeOut = 5 * time.Second
@@ -69,9 +69,9 @@ func (j *JobSpec) execCommandWithRetry(trigger string, supressLogs bool) {
 
 		switch {
 		case tries == 0:
-			jr = j.execCommand(trigger, supressLogs)
+			jr = j.execCommand(trigger, suppressLogs)
 		default:
-			jr = j.execCommand(fmt.Sprintf("%s[retry=%v]", trigger, tries), supressLogs)
+			jr = j.execCommand(fmt.Sprintf("%s[retry=%v]", trigger, tries), suppressLogs)
 		}
 
 		if jr.Status == 0 {

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -16,7 +16,7 @@ func ConfigLogger(prettyLog bool, logLevel string, extraWriters ...io.Writer) {
 	var multi zerolog.LevelWriter
 
 	const logFile string = "core.cheek.jsonl"
-	logFn := path.Join(cheekPath(), logFile)
+	logFn := path.Join(CheekPath(), logFile)
 
 	f, err := os.OpenFile(logFn,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/pkg/schedule_test.go
+++ b/pkg/schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,7 +13,7 @@ func TestScheduleRun(t *testing.T) {
 	// rough test
 	// just tries to see if we can get to a job trigger
 	// and to see that exit signals are received correctly
-
+	viper.Set("port", "9999")
 	proc, err := os.FindProcess(os.Getpid())
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +21,7 @@ func TestScheduleRun(t *testing.T) {
 	b := new(tsBuffer)
 	ConfigLogger(false, "debug", b)
 	go func() {
-		RunSchedule("../testdata/jobs1.yaml", "9999", true)
+		RunSchedule("../testdata/jobs1.yaml", true)
 	}()
 
 	time.Sleep(2 * time.Second)

--- a/pkg/tui.go
+++ b/pkg/tui.go
@@ -57,7 +57,6 @@ type model struct {
 	hx            string
 	listFocus     bool
 	viewportFocus bool
-	httpPort      string
 	viewport      viewport.Model
 }
 

--- a/pkg/tui.go
+++ b/pkg/tui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -99,7 +100,7 @@ func (m model) Init() tea.Cmd {
 
 func refreshState() tea.Msg {
 	schedule := &Schedule{}
-	if err := schedule.getSchedule(serverPort, yamlFile); err != nil {
+	if err := schedule.getSchedule(yamlFile); err != nil {
 		fmt.Print(err.Error())
 		os.Exit(1)
 	}
@@ -237,9 +238,9 @@ func (m model) View() string {
 	return mv
 }
 
-func (s *Schedule) getSchedule(httpPort string, scheduleFile string) error {
+func (s *Schedule) getSchedule(scheduleFile string) error {
 	// addr should be configurable
-	r, server_err := http.Get(fmt.Sprintf("http://localhost:%s/schedule", httpPort))
+	r, server_err := http.Get(fmt.Sprintf("http://localhost:%s/schedule", serverPort))
 	if server_err == nil {
 		defer r.Body.Close()
 		return json.NewDecoder(r.Body).Decode(s)
@@ -256,12 +257,16 @@ func (s *Schedule) getSchedule(httpPort string, scheduleFile string) error {
 }
 
 // TUI is the main entrypoint for the cheek ui.
-func TUI(httpPort string, scheduleFile string) {
-	serverPort = httpPort
+func TUI(scheduleFile string) {
+	if !viper.IsSet("port") {
+		fmt.Println("port value not found and no default set")
+		os.Exit(1)
+	}
+	serverPort = viper.GetString("port")
 	yamlFile = scheduleFile
 	// init schedule schedule
 	schedule := &Schedule{}
-	if err := schedule.getSchedule(httpPort, scheduleFile); err != nil {
+	if err := schedule.getSchedule(scheduleFile); err != nil {
 		fmt.Printf("Error connecting with cheek server: %v\n", err.Error())
 		os.Exit(1)
 	}
@@ -277,7 +282,7 @@ func TUI(httpPort string, scheduleFile string) {
 	l.SetShowHelp(false)
 	l.SetShowTitle(false)
 
-	m := model{list: l, state: schedule, listFocus: true, httpPort: httpPort}
+	m := model{list: l, state: schedule, listFocus: true}
 
 	if err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Start(); err != nil {
 		fmt.Println("Error running program:", err)

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -11,12 +11,20 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
-func cheekPath() string {
-	usr, _ := user.Current()
-	dir := usr.HomeDir
-	p := path.Join(dir, ".cheek")
+func CheekPath() string {
+	var p string
+	switch viper.IsSet("homedir") {
+	case true:
+		p = viper.GetString("homedir")
+	default:
+		usr, _ := user.Current()
+		dir := usr.HomeDir
+		p = path.Join(dir, ".cheek")
+	}
+
 	_ = os.MkdirAll(p, os.ModePerm)
 
 	return p

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -1,9 +1,11 @@
 package cheek
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLastLineReader(t *testing.T) {
@@ -47,4 +49,12 @@ func TestHardWrap(t *testing.T) {
 	test := "12345678"
 	assert.Equal(t, hardWrap(test, 5), "12345\n678")
 	assert.Equal(t, hardWrap(test, 2), "12\n34\n56\n78")
+}
+
+func TestCheekPath(t *testing.T) {
+	assert.True(t, strings.Contains(CheekPath(), ".cheek"))
+
+	viper.Set("homedir", "moo_i_am_sheep")
+	assert.True(t, strings.Contains(CheekPath(), "sheep"))
+
 }

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -56,5 +56,4 @@ func TestCheekPath(t *testing.T) {
 
 	viper.Set("homedir", "moo_i_am_sheep")
 	assert.True(t, strings.Contains(CheekPath(), "sheep"))
-
 }


### PR DESCRIPTION
Double down on viper, allows us not to have to pass down flags to all sub funcs but just use viper.

Added some minimal testing to test my own assumptions on this.

Setting `pretty` by default to `true`.