### PR TITLE
Respect the gronx

### DIFF
--- a/pkg/schedule.go
+++ b/pkg/schedule.go
@@ -26,7 +26,7 @@ type Schedule struct {
 // Run a Schedule based on its specs.
 func (s *Schedule) Run() {
 	gronx := gronx.New()
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Minute)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 

--- a/pkg/schedule_test.go
+++ b/pkg/schedule_test.go
@@ -25,7 +25,7 @@ func TestScheduleRun(t *testing.T) {
 		RunSchedule(logger, Config{}, "../testdata/jobs1.yaml")
 	}()
 
-	time.Sleep(3 * time.Second)
+	time.Sleep((1 * time.Minute) + (1 * time.Second))
 	if err := proc.Signal(os.Interrupt); err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestScheduleRun(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	spew.Dump(b.String())
 	assert.Contains(t, b.String(), "Job triggered")
-	// assert.Contains(t, b.String(), "interrupt signal received")
+	assert.Contains(t, b.String(), "interrupt signal received")
 
 	// check that job gets triggered by other job
 	assert.Contains(t, b.String(), "\"trigger\":\"job[foo]")


### PR DESCRIPTION
So.. we're ticking every second. While minimal time diff in cron is a minute. This means that for e.g. `* * * * *` (run every minute) our jobs actually are triggered every second, because they're due the full minute 🤦 .
