### PR TITLE
fix: get homedirectory with `os.UserHomeDir` to avoid nil pointer panic

### DIFF
--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path"
 	"sync"
 
@@ -81,8 +80,7 @@ func CheekPath() string {
 	case true:
 		p = viper.GetString("homedir")
 	default:
-		usr, _ := user.Current()
-		dir := usr.HomeDir
+		dir, _ := os.UserHomeDir()
 		p = path.Join(dir, ".cheek")
 	}
 


### PR DESCRIPTION
I get the following panic when running cheek on a [gokrazy](https://github.com/gokrazy/gokrazy) environment:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6ca700]

goroutine 1 [running]:
github.com/datarootsio/cheek/pkg.CheekPath()
	/Users/paul/go/pkg/mod/github.com/datarootsio/cheek@v1.0.16/pkg/utils.go:85 +0x74
github.com/datarootsio/cheek/cmd.init.0()
	/Users/paul/go/pkg/mod/github.com/datarootsio/cheek@v1.0.16/cmd/root.go:34 +0x7c
```

This PR fixes it