### PR TITLE
Feature: add custom marshaller for env vars to hide them in the UI

### DIFF
--- a/pkg/job.go
+++ b/pkg/job.go
@@ -40,7 +40,7 @@ type JobSpec struct {
 
 	Name             string            `json:"name"`
 	Retries          int               `yaml:"retries,omitempty" json:"retries,omitempty"`
-	Env              map[string]string `yaml:"env,omitempty"`
+	Env              map[string]secret `yaml:"env,omitempty"`
 	WorkingDirectory string            `yaml:"working_directory,omitempty" json:"working_directory,omitempty"`
 	globalSchedule   *Schedule
 	Runs             []JobRun `json:"runs" yaml:"-"`
@@ -48,6 +48,13 @@ type JobSpec struct {
 	nextTick time.Time
 	log      zerolog.Logger
 	cfg      Config
+}
+
+type secret string
+
+// custom marshaller to hide secrets
+func (secret) MarshalText() ([]byte, error) {
+	return []byte("***"), nil
 }
 
 // JobRun holds information about a job execution.

--- a/pkg/job_test.go
+++ b/pkg/job_test.go
@@ -2,6 +2,7 @@ package cheek
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -317,7 +318,7 @@ func TestJobWithBashEval(t *testing.T) {
 			"bash", "-c", "MY_VAR=$(date +%Y-%m); echo $MY_VAR $FOO",
 		},
 		// add random Env to check if it passes through
-		Env: map[string]string{
+		Env: map[string]secret{
 			"FOO": "BAR",
 		},
 		cfg: NewConfig(),
@@ -406,4 +407,20 @@ func TestExecCommandExitError(t *testing.T) {
 	assert.NotEmpty(t, result.Log, "Expected log to contain some content")
 	assert.NotNil(t, result.Duration, "Expected duration to be set")
 	assert.GreaterOrEqual(t, result.Duration.Milliseconds(), int64(0), "Expected positive duration")
+}
+
+func TestMarshalSecret(t *testing.T) {
+	secrets := map[string]secret{"foo": "bar"}
+
+	yamlResult, err := yaml.Marshal(secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, string(yamlResult), "foo: '***'\n")
+
+	jsonResult, err := json.Marshal(secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, string(jsonResult), `{"foo":"***"}`)
 }


### PR DESCRIPTION
I am using cheek to trigger regular backups with restic and need to pass the credentials as environment variables. These credentials should remain on the device and should not be accessible via the API or be displayed in the UI. Thus, I introduced a custom marshaller that replaces them with "***"