### PR TITLE
Show first run before job name & fix iteration

### DIFF
--- a/pkg/web_assets/static/styles.css
+++ b/pkg/web_assets/static/styles.css
@@ -4,3 +4,34 @@
   font-weight: 100 900;
   font-style: normal;
 }
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 200px;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  font-size: 14px;
+  line-height: 1.4;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}

--- a/pkg/web_assets/templates/overview.html
+++ b/pkg/web_assets/templates/overview.html
@@ -1,12 +1,14 @@
 {{ define "content"}}
 <div class="pt-4 pb-2">
-  <template x-for="job in $store.jobs.jobs" :key="job" x-data>
+  <template x-for="job in $store.jobs.jobs" x-data>
     <div class="flex flex-wrap items-center">
-      <a class="pr-2 text-slate-200 hover:text-lime-200" :href="`/jobs/${job.name}/latest`" x-text="job.name"></a>
+      <!-- display only the most recent run before the job name -->
       <template x-if="job.runs !== null">
-        <template x-for="run in job.runs">
-          <a class="pr-1" :href="`/jobs/${job.name}/${run.id}`"><abbr class="no-underline"
-              :title="`${truncateDateTime(run.triggered_at)}`">
+        <template x-for="(run, index) in job.runs" :key="index">
+          <template x-if="index === 0">
+            <a class="pr-2" :href="`/jobs/${job.name}/${run.id}`">
+              <abbr class="no-underline tooltip" :title="`${truncateDateTime(run.triggered_at)}`">
+                <span class="tooltiptext" x-text="`${truncateDateTime(run.triggered_at)}`"></span>
 
               <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"
                 :class="run.status === 0 ? 'fill-emerald-600' : run.status === undefined ? 'fill-orange-300' : 'fill-red-600'">
@@ -18,6 +20,41 @@
               </svg>
             </abbr>
           </a>
+          </template>
+        </template>
+      </template>
+
+      <template x-if="job.runs === null">
+        <abbr class="no-underline pr-2 tooltip" title="never ran">
+          <span class="tooltiptext">never ran</span>
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" class="fill-slate-200">
+            <g>
+              <path
+                d="M6.03 1.01c-2.78 0-5.03 2.24-5.03 5.02s2.24 5.03 5.03 5.03 5.03-2.24 5.02-5.03-2.24-5.03-5.02-5.02z">
+              </path>
+            </g>
+          </svg>
+        </abbr>
+      </template>
+
+      <a class="pr-2 text-slate-200 hover:text-lime-200" :href="`/jobs/${job.name}/latest`" x-text="job.name"></a>
+      <template x-if="job.runs !== null">
+        <template x-for="(run, index) in job.runs" :key="index">
+          <template x-if="index !== 0">
+            <a class="pr-1" :href="`/jobs/${job.name}/${run.id}`">
+              <abbr class="no-underline tooltip" :title="`${truncateDateTime(run.triggered_at)}`">
+                <span class="tooltiptext" x-text="`${truncateDateTime(run.triggered_at)}`"></span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"
+                  :class="run.status === 0 ? 'fill-emerald-600' : run.status === undefined ? 'fill-orange-300' : 'fill-red-600'">
+                  <g>
+                    <path
+                      d="M6.03 1.01c-2.78 0-5.03 2.24-5.03 5.02s2.24 5.03 5.03 5.03 5.03-2.24 5.02-5.03-2.24-5.03-5.02-5.02z">
+                    </path>
+                  </g>
+                </svg>
+              </abbr>
+            </a>
+          </template>
         </template>
       </template>
     </div>


### PR DESCRIPTION
Hey there, first of all thank you for this **awesome** project! ❤️

I have > 200 jobs and spotting those which failed became very hard.  So I moved the status indicator for the most recent run before the job name.  This way I can easily see which run failed.  I also added a real tooltip over the indicators, so that the last run timestamp pops up immediately, and fixed a small Alpine issue.

![SCR-20241212-tmdg](https://github.com/user-attachments/assets/7f49b631-ad8e-471f-a057-41962523ff19)

Perhaps you're interested in pulling this.