### PR TITLE
Navigate to latest job run after triggering via web UI

### DIFF
--- a/pkg/web_assets/templates/jobview.html
+++ b/pkg/web_assets/templates/jobview.html
@@ -3,7 +3,7 @@
   <div class="flex gap-2">
     <div class="w-1/6 text-xs flex flex-col gap-2">
       <div class="flex gap-2" x-data="{showNotification: false, notification: ''}">
-        <button id="trigger" class="fill-slate-200 hover:fill-lime-200" @click="triggerJob($store.job.jobName); showNotification = true; notification = 'triggered'; setTimeout(() => showNotification = false, 2000)">
+        <button id="trigger" class="fill-slate-200 hover:fill-lime-200" @click="triggerJob($store.job.jobName); showNotification = true; notification = 'triggered'; setTimeout(async () => { showNotification = false; window.location.href = `/jobs/${$store.job.jobName}/latest`; }, 2000)">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"
             >
             <g>

--- a/pkg/web_assets/templates/jobview.html
+++ b/pkg/web_assets/templates/jobview.html
@@ -3,7 +3,7 @@
   <div class="flex gap-2">
     <div class="w-1/6 text-xs flex flex-col gap-2">
       <div class="flex gap-2" x-data="{showNotification: false, notification: ''}">
-        <button id="trigger" class="fill-slate-200 hover:fill-lime-200" @click="triggerJob($store.job.jobName); showNotification = true; notification = 'triggered'; setTimeout(async () => { showNotification = false; window.location.href = `/jobs/${$store.job.jobName}/latest`; }, 2000)">
+        <button id="trigger" class="fill-slate-200 hover:fill-lime-200" @click="triggerJob($store.job.jobName); showNotification = true; notification = 'triggered'; setTimeout(() => { showNotification = false; window.location.href = `/jobs/${$store.job.jobName}/latest`; }, 2000)">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"
             >
             <g>


### PR DESCRIPTION
When triggering a job from the web UI, the page now automatically navigates to the newly triggered job’s output after 2 seconds. This eliminates the need to manually click the **Refresh** button and then locate and click the latest job run. I was torn between reusing the logic in the refresh onclick handler and then navigating to the latest job via JS, but in the spirit of this project I feel that something like

```js
window.location.href = `/jobs/${$store.job.jobName}/latest`;
```

gets the job done with minimal complications.

Changes:
 - Modified the trigger button in jobview.html to redirect to /jobs/{jobName}/latest after showing the "triggered" notification

Testing
- Tested by triggering jobs from the UI and verifying the redirect behavior works as expected.