### PR TITLE
Add on_retries_exhausted event for to expand on retry handling

### DIFF
--- a/pkg/job_test.go
+++ b/pkg/job_test.go
@@ -317,9 +317,10 @@ func TestOnRetriesExhausted(t *testing.T) {
 		}
 
 		// Check if this is a retries exhausted webhook (based on the URL path or body content)
-		if r.URL.Path == "/retries-exhausted" {
+		switch r.URL.Path {
+		case "/retries-exhausted":
 			retriesExhaustedTriggered = true
-		} else if r.URL.Path == "/error" {
+		case "/error":
 			errorTriggeredCount++
 		}
 

--- a/pkg/schedule.go
+++ b/pkg/schedule.go
@@ -17,13 +17,14 @@ import (
 
 // Schedule defines specs of a job schedule.
 type Schedule struct {
-	Jobs       map[string]*JobSpec `yaml:"jobs" json:"jobs"`
-	OnSuccess  OnEvent             `yaml:"on_success,omitempty" json:"on_success,omitempty"`
-	OnError    OnEvent             `yaml:"on_error,omitempty" json:"on_error,omitempty"`
-	TZLocation string              `yaml:"tz_location,omitempty" json:"tz_location,omitempty"`
-	loc        *time.Location
-	log        zerolog.Logger
-	cfg        Config
+	Jobs               map[string]*JobSpec `yaml:"jobs" json:"jobs"`
+	OnSuccess          OnEvent             `yaml:"on_success,omitempty" json:"on_success,omitempty"`
+	OnError            OnEvent             `yaml:"on_error,omitempty" json:"on_error,omitempty"`
+	OnRetriesExhausted OnEvent             `yaml:"on_retries_exhausted,omitempty" json:"on_retries_exhausted,omitempty"`
+	TZLocation         string              `yaml:"tz_location,omitempty" json:"tz_location,omitempty"`
+	loc                *time.Location
+	log                zerolog.Logger
+	cfg                Config
 }
 
 func (s *Schedule) Run() {

--- a/testdata/readme_example.yaml
+++ b/testdata/readme_example.yaml
@@ -24,3 +24,10 @@ jobs:
         - https://webhook.site/4b732eb4-ba10-4a84-8f6b-30167b2f2762
       notify_slack_webhook: # notify slack via a slack compatible webhook
         - https://webhook.site/048ff47f-9ef5-43fb-9375-a795a8c5cbf5
+    on_retries_exhausted:
+      trigger_job: # only fires once when all retries fail
+        - cleanup_job
+      notify_webhook:
+        - https://webhook.site/critical-alerts
+  cleanup_job:
+    command: echo "Cleaning up after failed coffee job"


### PR DESCRIPTION
- Add OnRetriesExhausted field to JobSpec and Schedule structs
- Implement retry exhaustion detection logic in execCommandWithRetryContext
- Create separate OnRetriesExhaustedEvent handler for retries exhausted events
- Add retry context fields (retry_attempt, retries_exhausted) to JobRun struct
- Enhance webhook payloads with retry information for better observability
- Add comprehensive test coverage for all retry exhaustion scenarios
- Update documentation and examples showing on_retries_exhausted usage

The on_retries_exhausted event fires once when all configured retries fail, providing granular control over retry vs final failure handling. The on_error event continues to fire after each failed attempt, maintaining backward compatibility.

Links to #259 