### PR TITLE
Migrate from Google Cloud Storage to GitHub releases for artifact distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,28 +92,31 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - run: mkdir -p ${{ matrix.goos }}/${{ matrix.goarch }}
       - run: env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-X 'github.com/datarootsio/cheek/pkg.version=${{ needs.version_tag.outputs.new_tag }}' -X 'github.com/datarootsio/cheek/pkg.commitSHA=${{ steps.vars.outputs.sha_short }}'" -o ${{ matrix.goos }}/${{ matrix.goarch }}
-      - run: cp ${{ matrix.goos }}/${{ matrix.goarch }}/cheek ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ steps.vars.outputs.sha_short }}
-      - run: cp ${{ matrix.goos }}/${{ matrix.goarch }}/cheek ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ needs.version_tag.outputs.new_tag }}
-      ## upload binary to google storage
-      - id: auth
-        uses: google-github-actions/auth@v2.1.7
+      - run: cp ${{ matrix.goos }}/${{ matrix.goarch }}/cheek ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ matrix.goos }}-${{ matrix.goarch }}
+      ## upload artifacts for release
+      - uses: actions/upload-artifact@v4
         with:
-          credentials_json: ${{ secrets.gcp_credentials_cheek }}
-      - id: upload-files
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
+          name: cheek-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  release:
+    if: github.ref == 'refs/heads/main' && needs.version_tag.outputs.new_tag != ''
+    needs: 
+      - build
+      - version_tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ steps.vars.outputs.sha_short }}
-          destination: cheek-scheduler/${{ matrix.goos }}/${{ matrix.goarch }}/
-      - uses: google-github-actions/upload-cloud-storage@v2.2.1
-        if: github.ref == 'refs/heads/main'
+          path: artifacts
+      - name: Create release
+        uses: softprops/action-gh-release@v2
         with:
-          path: ${{ matrix.goos }}/${{ matrix.goarch }}/cheek-${{ needs.version_tag.outputs.new_tag }}
-          destination: cheek-scheduler/${{ matrix.goos }}/${{ matrix.goarch }}/
-      - uses: google-github-actions/upload-cloud-storage@v2.2.1
-        if: github.ref == 'refs/heads/main'
-        with:
-          path: ${{ matrix.goos }}/${{ matrix.goarch }}/cheek
-          destination: cheek-scheduler/${{ matrix.goos }}/${{ matrix.goarch }}/
+          tag_name: ${{ needs.version_tag.outputs.new_tag }}
+          name: Release ${{ needs.version_tag.outputs.new_tag }}
+          files: artifacts/*/cheek-*
+          generate_release_notes: true
 
   docker-build:
     ## only do this on main

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@
 
 Fetch the latest version for your system below.
 
-[darwin-arm64](https://storage.googleapis.com/cheek-scheduler/darwin/arm64/cheek) |
-[darwin-amd64](https://storage.googleapis.com/cheek-scheduler/darwin/amd64/cheek) |
-[linux-386](https://storage.googleapis.com/cheek-scheduler/linux/386/cheek) |
-[linux-arm64](https://storage.googleapis.com/cheek-scheduler/linux/arm64/cheek) |
-[linux-amd64](https://storage.googleapis.com/cheek-scheduler/linux/amd64/cheek)
+[darwin-arm64](https://github.com/datarootsio/cheek/releases/latest/download/cheek-darwin-arm64) |
+[darwin-amd64](https://github.com/datarootsio/cheek/releases/latest/download/cheek-darwin-amd64) |
+[linux-386](https://github.com/datarootsio/cheek/releases/latest/download/cheek-linux-386) |
+[linux-arm64](https://github.com/datarootsio/cheek/releases/latest/download/cheek-linux-arm64) |
+[linux-amd64](https://github.com/datarootsio/cheek/releases/latest/download/cheek-linux-amd64)
 
 You can (for example) fetch it like below, make it executable and run it. Optionally put `cheek` on your `PATH`.
 
 ```sh
-curl https://storage.googleapis.com/cheek-scheduler/darwin/amd64/cheek -o cheek
+curl -L https://github.com/datarootsio/cheek/releases/latest/download/cheek-darwin-amd64 -o cheek
 chmod +x cheek
 ./cheek
 ```
@@ -231,16 +231,14 @@ Prebuilt images are available at `ghcr.io/datarootsio/cheek:latest` where `lates
 
 If you want to pin your setup to a specific version of `cheek` you can use the following template to fetch your `cheek` binary:
 
-- latest version: https://storage.googleapis.com/cheek-scheduler/{os}/{arch}/cheek
-- tagged version: https://storage.googleapis.com/cheek-scheduler/{os}/{arch}/cheek-{tag}
-- `main` branch builds: https://storage.googleapis.com/cheek-scheduler/{os}/{arch}/cheek-{shortsha}
+- latest version: https://github.com/datarootsio/cheek/releases/latest/download/cheek-{os}-{arch}
+- tagged version: https://github.com/datarootsio/cheek/releases/download/{tag}/cheek-{os}-{arch}
 
 Where:
 
 - `os` is one of `linux`, `darwin`
 - `arch` is one of `amd64`, `arm64`, `386`
 - `tag` is one the [available tags](https://github.com/datarootsio/cheek/tags)
-- `shortsha` is a 7-char SHA and most commits on `main` will be available
 
 ## Acknowledgements
 


### PR DESCRIPTION
Replaces GCS uploads with GitHub releases to eliminate external cloud dependency.
Updates CI workflow to use actions/upload-artifact and softprops/action-gh-release.
Updates README download links to use GitHub releases URLs.
